### PR TITLE
Make it runnable on newer logstashes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-gem "logstash", :github => "elasticsearch/logstash", :branch => "1.5"

--- a/logstash-input-jms.gemspec
+++ b/logstash-input-jms.gemspec
@@ -19,15 +19,11 @@ Gem::Specification.new do |s|
 	# Special flag to let us know this is actually a logstash plugin
 	s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-	# Gem dependencies
-	s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
+	s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
 	s.add_runtime_dependency 'logstash-codec-plain'
 	s.add_runtime_dependency 'logstash-codec-json'
 
-	if RUBY_PLATFORM == 'java'
-		s.platform = RUBY_PLATFORM
-		s.add_runtime_dependency "jruby-jms" #(Apache 2.0 license)
-	end
+  s.add_runtime_dependency "jruby-jms" #(Apache 2.0 license)
 	s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
The specs now run, but this errors for me on tests. Any ideas?

```
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/jruby --1.9 -X+O -J-Djruby.compile.mode=OFF -J-Djruby.debug.fullTrace=true -e at_exit{sleep(1)};$stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift) /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/ruby-debug-ide-0.4.32/bin/rdebug-ide --disable-int-handler --evaluation-timeout 10 --rubymine-protocol-extensions --port 55137 --dispatcher-port 55138 -- /Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec /Users/andrewvc/projects/logstash-output-jms/spec/outputs/jms_spec.rb --require teamcity/spec/runner/formatter/teamcity/formatter --format Spec::Runner::Formatter::TeamcityFormatter --backtrace
Testing started at 4:47 PM ...
Fast Debugger (ruby-debug-ide 0.4.32, ruby-debug-base 0.10.5.rc10) listens on 127.0.0.1:55137
Using Accessor#strict_set for specs
E, [2015-07-17T16:47:47.545000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/hornetq-commons.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/hornetq-commons
E, [2015-07-17T16:47:47.553000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/hornetq-core-client.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/hornetq-core-client
E, [2015-07-17T16:47:47.561000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/hornetq-jms-client.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/hornetq-jms-client
E, [2015-07-17T16:47:47.567000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/jboss-jms-api.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/jboss-jms-api
E, [2015-07-17T16:47:47.574000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/jnp-client.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/jnp-client
E, [2015-07-17T16:47:47.582000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/netty.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/netty

NameError: cannot load Java class javax.jms.DeliveryMode
org/jruby/javasupport/JavaClass.java:204:in `for_name'
org/jruby/javasupport/JavaUtilities.java:34:in `get_proxy_class'
file:/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/jruby.jar!/jruby/java/core_ext/object.rb:27:in `java_import'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
file:/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/jruby.jar!/jruby/java/core_ext/object.rb:22:in `java_import'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/imports.rb:3:in `JMS'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/imports.rb:2:in `(root)'
org/jruby/RubyKernel.java:1072:in `require'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1:in `(root)'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:69:in `require'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/connection.rb:116:in `fetch_dependencies'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/connection.rb:175:in `initialize'
./lib/logstash/outputs/jms.rb:98:in `register'
org/jruby/RubyBasicObject.java:1566:in `instance_exec'
./spec/outputs/jms_spec.rb:30:in `(root)'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:152:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:329:in `with_around_example_hooks'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:149:in `run'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:490:in `run_examples'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:486:in `run_examples'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:453:in `run'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `run_specs'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `run_specs'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:53:in `report'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:107:in `run_specs'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:85:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
org/jruby/RubyKernel.java:1091:in `load'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/exe/rspec:4:in `(root)'
org/jruby/debug/RubyDebugger.java:204:in `debug_load'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec:1:in `(root)'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec:23:in `(root)'
org/jruby/RubyKernel.java:1091:in `load'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/ruby-debug-ide-0.4.32/lib/ruby-debug-ide.rb:1:in `(root)'
E, [2015-07-17T16:47:47.624000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/hornetq-commons.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/hornetq-commons
E, [2015-07-17T16:47:47.630000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/hornetq-core-client.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/hornetq-core-client
E, [2015-07-17T16:47:47.636000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/hornetq-jms-client.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/hornetq-jms-client
E, [2015-07-17T16:47:47.641000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/jboss-jms-api.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/jboss-jms-api
E, [2015-07-17T16:47:47.647000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/jnp-client.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/jnp-client
E, [2015-07-17T16:47:47.652000 #61960] ERROR -- : Failed to Load Jar File:/Applications/hornetq-2.4.0.Final/lib/netty.jar. no such file to load -- /Applications/hornetq-2.4.0.Final/lib/netty

expected no Exception, got #<NameError: cannot load Java class javax.jms.DeliveryMode> with backtrace:
  # org/jruby/javasupport/JavaClass.java:204:in `for_name'
  # org/jruby/javasupport/JavaUtilities.java:34:in `get_proxy_class'
  # file:/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/jruby.jar!/jruby/java/core_ext/object.rb:27:in `java_import'
  # org/jruby/RubyArray.java:2399:in `collect'
  # org/jruby/RubyArray.java:2412:in `map'
  # file:/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/jruby.jar!/jruby/java/core_ext/object.rb:22:in `java_import'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/imports.rb:3:in `JMS'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/imports.rb:2:in `(root)'
  # org/jruby/RubyKernel.java:1072:in `require'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1:in `(root)'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:69:in `require'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/connection.rb:116:in `fetch_dependencies'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/jruby-jms-1.1.0-java/lib/jms/connection.rb:175:in `initialize'
  # ./lib/logstash/outputs/jms.rb:98:in `register'
  # org/jruby/RubyProc.java:290:in `call'
  # org/jruby/RubyProc.java:271:in `call'
  # ./spec/outputs/jms_spec.rb:18:in `(root)'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/matchers/built_in/raise_error.rb:43:in `matches?'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/matchers/built_in/raise_error.rb:62:in `does_not_match?'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/handler.rb:75:in `does_not_match?'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/handler.rb:70:in `handle_matcher'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/expectation_target.rb:67:in `not_to'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/expectation_target.rb:92:in `not_to'
  # org/jruby/RubyBasicObject.java:1566:in `instance_exec'
  # ./spec/outputs/jms_spec.rb:18:in `(root)'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:152:in `run'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:329:in `with_around_example_hooks'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:149:in `run'
  # org/jruby/RubyArray.java:2399:in `collect'
  # org/jruby/RubyArray.java:2412:in `map'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:490:in `run_examples'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:486:in `run_examples'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:453:in `run'
  # org/jruby/RubyArray.java:2399:in `collect'
  # org/jruby/RubyArray.java:2412:in `map'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
  # org/jruby/RubyArray.java:2399:in `collect'
  # org/jruby/RubyArray.java:2412:in `map'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `run_specs'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `run_specs'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:53:in `report'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:107:in `run_specs'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:85:in `run'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
  # org/jruby/RubyKernel.java:1091:in `load'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/exe/rspec:4:in `(root)'
  # org/jruby/debug/RubyDebugger.java:204:in `debug_load'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec:1:in `(root)'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec:23:in `(root)'
  # org/jruby/RubyKernel.java:1091:in `load'
  # /Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/ruby-debug-ide-0.4.32/lib/ruby-debug-ide.rb:1:in `(root)'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/fail_with.rb:30:in `fail_with'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/handler.rb:37:in `handle_failure'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/handler.rb:70:in `handle_matcher'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/expectation_target.rb:67:in `not_to'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-expectations-3.1.2/lib/rspec/expectations/expectation_target.rb:92:in `not_to'
./spec/outputs/jms_spec.rb:18:in `(root)'
org/jruby/RubyBasicObject.java:1566:in `instance_exec'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:152:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:329:in `with_around_example_hooks'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example.rb:149:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:490:in `run_examples'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:486:in `run_examples'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:453:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:454:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `run_specs'
org/jruby/RubyArray.java:2399:in `collect'
org/jruby/RubyArray.java:2412:in `map'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:111:in `run_specs'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:53:in `report'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:107:in `run_specs'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:85:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/rspec-core-3.1.7/exe/rspec:4:in `(root)'
org/jruby/RubyKernel.java:1091:in `load'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec:1:in `(root)'
org/jruby/debug/RubyDebugger.java:204:in `debug_load'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/bin/rspec:23:in `(root)'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/ruby-debug-ide-0.4.32/lib/ruby-debug-ide.rb:1:in `(root)'
org/jruby/RubyKernel.java:1091:in `load'
/Users/andrewvc/.rbenv/versions/jruby-1.7.20/lib/ruby/gems/shared/gems/ruby-debug-ide-0.4.32/lib/ruby-debug-ide.rb:86:in `debug_program'

3 examples, 2 failures, 1 passed

Finished in 0.473 seconds


Randomized with seed 8783


Process finished with exit code 0

```
